### PR TITLE
Propagate failed tests to exit code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,11 @@ on:
       - 'LICENSE.md'
       - 'README.md'
   workflow_dispatch:
+    inputs:
+      debug_enabled:
+        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'     
+        required: false
+        default: false
 
 jobs:
   test:
@@ -54,12 +59,13 @@ jobs:
       - name: Build
         run: |
           make -f HOHQMesh.mak -j 2 F90=${{ matrix.compiler }}
-      # - name: Setup tmate session for debugging
-      #   if: ${{ matrix.os == 'windows-latest' }}
-      #   uses: mxschmitt/action-tmate@v3
       - name: Run tests
         run: |
           ./HOHQMesh -test
+      # Enable tmate debugging of manually-triggered workflows if the input option was provided
+      - name: Setup tmate session for debugging
+        if: ${{ matrix.os == 'windows-latest' && github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
+        uses: mxschmitt/action-tmate@v3
       - name: Run tests for coverage
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,9 @@ jobs:
           ./HOHQMesh -test
       # Enable tmate debugging of manually-triggered workflows if the input option was provided
       - name: Setup tmate session for debugging
-        if: ${{ matrix.os == 'windows-latest' && github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
+        if: ${{ matrix.os == 'windows-latest' && github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled && always() }}
         uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 15
       - name: Run tests for coverage
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Bootstrap
         run: |
           ./bootstrap
+      - name: Show version information
+        run: |
+          ${{ matrix.compiler }} --version
       - name: Build
         run: |
           make -f HOHQMesh.mak -j 2 F90=${{ matrix.compiler }}

--- a/Source/HOHQMeshMain.f90
+++ b/Source/HOHQMeshMain.f90
@@ -91,7 +91,7 @@
          IF ( test )     THEN
          
             printMessage    = .FALSE.
-            CALL RunTests(pathToTestFiles = path, numberOfFailedTestsRet = numberOfFailedTests)
+            CALL RunTests(pathToTestFiles = path, numberOfFailedTests = numberOfFailedTests)
             
          ELSE 
          

--- a/Source/HOHQMeshMain.f90
+++ b/Source/HOHQMeshMain.f90
@@ -79,6 +79,7 @@
          LOGICAL          :: didGenerate3DMesh = .FALSE.
 
          TYPE(testData)   :: tData
+         INTEGER          :: numberOfFailedTests = 0
 !
 !        ***********************************************
 !                             Start
@@ -90,7 +91,7 @@
          IF ( test )     THEN
          
             printMessage    = .FALSE.
-            CALL RunTests(pathToTestFiles = path)
+            CALL RunTests(pathToTestFiles = path, numberOfFailedTestsRet = numberOfFailedTests)
             
          ELSE 
          
@@ -136,6 +137,12 @@
 !
          CALL destructFTExceptions
          IF( PrintMessage ) PRINT *, "Execution complete. Exit."
+
+         IF ( numberOfFailedTests .gt. 0 )     THEN
+
+           ERROR STOP 'At least one test has failed'
+
+         END IF 
          
       END PROGRAM HOQMeshMain
 !
@@ -158,6 +165,7 @@
          
          IF ( CommandLineArgumentIsPresent("-version") )     THEN
             PRINT *, "HOMesh Version ", version
+            STOP
          END IF
          
          IF ( CommandLineArgumentIsPresent("-help") )     THEN

--- a/Source/Testing/MeshingTests.f90
+++ b/Source/Testing/MeshingTests.f90
@@ -72,7 +72,7 @@
 !
 !//////////////////////////////////////////////////////////////////////// 
 ! 
-   SUBROUTINE RunTests(pathToTestFiles)  
+   SUBROUTINE RunTests(pathToTestFiles, numberOfFailedTestsRet)
       IMPLICIT NONE
 !
 !     ---------
@@ -80,6 +80,7 @@
 !     ---------
 !
       CHARACTER(LEN=*) :: pathToTestFiles
+      INTEGER, OPTIONAL :: numberOfFailedTestsRet
 !
 !     ---------------
 !     Local variables
@@ -91,6 +92,7 @@
       CHARACTER(LEN=DEFAULT_CHARACTER_LENGTH) :: fullPath
       INTEGER                                 :: k
       EXTERNAL                                :: TestCurves
+      INTEGER                                 :: numberOfFailedTests
 !
 !     ------------------------------------------------------------------------------------
 !     The control files are located in a Benchmarks directory at the end of (if not empty)
@@ -132,8 +134,10 @@
 !     Run the tests
 !     -------------
 !
-      CALL testSuite % performTests()
+      CALL testSuite % performTests(numberOfFailedTests)
       CALL finalizeSharedAssertionsManager
+
+      IF(PRESENT(numberOfFailedTestsRet)) numberOfFailedTestsRet = numberOfFailedTests
       
    END SUBROUTINE RunTests
 !

--- a/Source/Testing/MeshingTests.f90
+++ b/Source/Testing/MeshingTests.f90
@@ -72,7 +72,7 @@
 !
 !//////////////////////////////////////////////////////////////////////// 
 ! 
-   SUBROUTINE RunTests(pathToTestFiles, numberOfFailedTestsRet)
+   SUBROUTINE RunTests(pathToTestFiles, numberOfFailedTests)
       IMPLICIT NONE
 !
 !     ---------
@@ -80,7 +80,7 @@
 !     ---------
 !
       CHARACTER(LEN=*) :: pathToTestFiles
-      INTEGER, OPTIONAL :: numberOfFailedTestsRet
+      INTEGER, INTENT(OUT) :: numberOfFailedTests
 !
 !     ---------------
 !     Local variables
@@ -92,7 +92,6 @@
       CHARACTER(LEN=DEFAULT_CHARACTER_LENGTH) :: fullPath
       INTEGER                                 :: k
       EXTERNAL                                :: TestCurves
-      INTEGER                                 :: numberOfFailedTests
 !
 !     ------------------------------------------------------------------------------------
 !     The control files are located in a Benchmarks directory at the end of (if not empty)
@@ -136,8 +135,6 @@
 !
       CALL testSuite % performTests(numberOfFailedTests)
       CALL finalizeSharedAssertionsManager
-
-      IF(PRESENT(numberOfFailedTestsRet)) numberOfFailedTestsRet = numberOfFailedTests
       
    END SUBROUTINE RunTests
 !


### PR DESCRIPTION
That is, if a test fails, now HOHQMesh fails with a non-zero exit code, making it easier to detect errors during CI testing.

Also amends `-version` flag to actually terminate.