### PR TITLE
Fix Makefile and update docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
           ${{ matrix.compiler }} --version
       - name: Build
         run: |
-          make -j 2 F90=${{ matrix.compiler }}
+          make -j 2 FC=${{ matrix.compiler }}
       - name: Run tests
         run: |
           ./HOHQMesh -test
@@ -74,7 +74,7 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
           sudo apt-get install -y lcov
-          F90=${{ matrix.compiler }} ./Utilities/createcoverage
+          FC=${{ matrix.compiler }} ./Utilities/createcoverage
       - uses: codecov/codecov-action@v1
         if: ${{ matrix.os == 'ubuntu-latest' }}
         with:

--- a/Documentation/docs/releasing-a-new-version.md
+++ b/Documentation/docs/releasing-a-new-version.md
@@ -81,10 +81,10 @@ tarball will fail!*
    current directory.
 5. Test the new release by executing
    ```bash
-   F90=gfortran ./Utilities/testrelease HOHQMesh-v1.3.0.tar.gz
+   FC=gfortran ./Utilities/testrelease HOHQMesh-v1.3.0.tar.gz
    ```
    Make sure you change the Fortran compiler executable to one suitable
-   for your system by modifying the `F90` environment variable accordingly.
+   for your system by modifying the `FC` environment variable accordingly.
    If it fails, do *not* just change the files in your current directory!
    Instead, figure out why the tests fail, fix them, commit and push the changes
    and start over.

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,11 @@
 # Modify the following for your local installation
 ##################################################
 #
-F90 = /usr/local/bin/gfortran
+FC = gfortran
 HOHQMESHPATH = .
 FTOLPATH = $(HOHQMESHPATH)/Contrib/FTObjectLibrary
 
-FFLAGS = -cpp -O
+FCFLAGS = -cpp -O
 ##########################
 # Object Files for build #
 ##########################
@@ -99,7 +99,7 @@ TransfiniteMapClass.o \
 Utilities.o \
 
 HOHQMesh : $(OBJS)
-	 ${F90}  -o $@ $(OBJS) $(LDFLAGS)
+	 ${FC}  -o $@ $(OBJS) $(LDFLAGS)
 
 #######################################
 # Object dependencies and compilation #
@@ -112,12 +112,12 @@ HexMeshObjects.o \
 SMMeshObjects.o \
 FatalErrorException.o \
 MeshProject.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/3DMeshController.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/3DMeshController.f90
 
 Assert.o : $(FTOLPATH)/Source/FTTesting/Assert.f90 \
 Comparisons.o \
 FTOLConstants.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTTesting/Assert.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTTesting/Assert.f90
 
 BoundaryEdgeCleaning.o :$(HOHQMESHPATH)/Source/Mesh/BoundaryEdgeCleaning.f90 \
 Connections.o \
@@ -125,7 +125,7 @@ ProgramGlobals.o \
 MeshBoundaryMethods.o \
 SMModel.o \
 SMMeshClass.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Mesh/BoundaryEdgeCleaning.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Mesh/BoundaryEdgeCleaning.f90
 
 ChainedSegmentedCurveClass.o :$(HOHQMESHPATH)/Source/Curves/DiscreteCurves/ChainedSegmentedCurveClass.f90 \
 FTExceptionClass.o \
@@ -136,21 +136,21 @@ FTObjectArrayClass.o \
 FTDataClass.o \
 SMConstants.o \
 ProgramGlobals.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/DiscreteCurves/ChainedSegmentedCurveClass.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/DiscreteCurves/ChainedSegmentedCurveClass.f90
 
 CommandLineReader.o :$(HOHQMESHPATH)/Source/Foundation/CommandLineReader.f90
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Foundation/CommandLineReader.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Foundation/CommandLineReader.f90
 
 Comparisons.o : $(FTOLPATH)/Source/FTTesting/Comparisons.f90 \
 FTOLConstants.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTTesting/Comparisons.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTTesting/Comparisons.f90
 
 Connections.o :$(HOHQMESHPATH)/Source/Mesh/Connections.f90 \
 FTLinkedListClass.o \
 SMMeshObjects.o \
 MeshOutputMethods.o \
 SMMeshClass.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Mesh/Connections.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Mesh/Connections.f90
 
 ControlFileReader.o :$(HOHQMESHPATH)/Source/IO/ControlFileReader.f90 \
 FTExceptionClass.o \
@@ -162,18 +162,18 @@ FTValueDictionaryClass.o \
 FTStackClass.o \
 FTLinkedListClass.o \
 FTDataClass.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/IO/ControlFileReader.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/IO/ControlFileReader.f90
 
 CurveConversions.o :$(HOHQMESHPATH)/Source/Curves/DiscreteCurves/CurveConversions.f90 \
 ChainedSegmentedCurveClass.o \
 SizerControls.o \
 SegmentedCurveArrayClass.o \
 SMChainedCurveClass.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/DiscreteCurves/CurveConversions.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/DiscreteCurves/CurveConversions.f90
 
 CurveInterpolantClass.o :$(HOHQMESHPATH)/Source/3DSource/Geometry/CurveInterpolantClass.f90 \
 InterpolationAndDerivatives.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/Geometry/CurveInterpolantClass.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/Geometry/CurveInterpolantClass.f90
 
 CurveTests.o : $(HOHQMESHPATH)/Source/Testing/CurveTests.f90 \
 SMConstants.o \
@@ -186,37 +186,37 @@ TestSuiteManagerClass.o \
 Assert.o \
 SMSplineCurveClass.o \
 SMTopographyClass.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Testing/CurveTests.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Testing/CurveTests.f90
 
 ElementOperations.o :$(HOHQMESHPATH)/Source/MeshObjects/ElementOperations.f90 \
 SMMeshClass.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/MeshObjects/ElementOperations.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/MeshObjects/ElementOperations.f90
 
 Encoder.o :$(HOHQMESHPATH)/Source/Foundation/Encoder.f90
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Foundation/Encoder.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Foundation/Encoder.f90
 
 EquationEvaluatorClass.o :$(HOHQMESHPATH)/Source/Curves/ContinuousCurves/EquationEvaluatorClass.f90
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/ContinuousCurves/EquationEvaluatorClass.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/ContinuousCurves/EquationEvaluatorClass.f90
 
 FatalErrorException.o :$(HOHQMESHPATH)/Source/Foundation/FatalErrorException.f90 \
 FTExceptionClass.o \
 FTValueClass.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Foundation/FatalErrorException.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Foundation/FatalErrorException.f90
 
 FileAndStringProcessing.o :$(HOHQMESHPATH)/Source/IO/FileAndStringProcessing.f90 \
 SMConstants.o \
 ProgramGlobals.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/IO/FileAndStringProcessing.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/IO/FileAndStringProcessing.f90
 
 fmin.o :$(HOHQMESHPATH)/Source/Curves/fmin.f90 \
 SMCurveClass.o \
 ProgramGlobals.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/fmin.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/fmin.f90
 
 Frenet.o :$(HOHQMESHPATH)/Source/3DSource/Geometry/Frenet.f90 \
 SMCurveClass.o \
 Geometry3D.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/Geometry/Frenet.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/Geometry/Frenet.f90
 
 FRSegmentedCurveClass.o :$(HOHQMESHPATH)/Source/Curves/DiscreteCurves/FRSegmentedCurveClass.f90 \
 SMConstants.o \
@@ -230,11 +230,11 @@ ProgramGlobals.o \
 Geometry.o \
 ObjectArrayAdditions.o \
 FTLinkedListClass.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/DiscreteCurves/FRSegmentedCurveClass.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/DiscreteCurves/FRSegmentedCurveClass.f90
 
 FTDataClass.o : $(FTOLPATH)/Source/FTObjects/FTDataClass.f90 \
 FTObjectClass.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTDataClass.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTDataClass.f90
 
 FTDictionaryClass.o : $(FTOLPATH)/Source/FTObjects/FTDictionaryClass.f90 \
 FTObjectArrayClass.o \
@@ -242,76 +242,76 @@ FTLinkedListClass.o \
 FTObjectClass.o \
 FTLinkedListClass.o \
 Hash.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTDictionaryClass.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTDictionaryClass.f90
 
 FTExceptionClass.o : $(FTOLPATH)/Source/FTObjects/FTExceptionClass.f90 \
 FTDictionaryClass.o \
 FTValueDictionaryClass.o \
 FTStackClass.o \
 FTLinkedListClass.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTExceptionClass.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTExceptionClass.f90
 
 FTLinkedListClass.o : $(FTOLPATH)/Source/FTObjects/FTLinkedListClass.f90 \
 FTObjectArrayClass.o \
 FTObjectClass.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTLinkedListClass.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTLinkedListClass.f90
 
 FTMultiIndexTable.o : $(FTOLPATH)/Source/FTObjects/FTMultiIndexTable.f90 \
 FTObjectClass.o \
 FTLinkedListClass.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTMultiIndexTable.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTMultiIndexTable.f90
 
 FTObjectArrayClass.o : $(FTOLPATH)/Source/FTObjects/FTObjectArrayClass.f90 \
 FTObjectClass.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTObjectArrayClass.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTObjectArrayClass.f90
 
 FTObjectClass.o : $(FTOLPATH)/Source/FTObjects/FTObjectClass.f90
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTObjectClass.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTObjectClass.f90
 
 FTOLConstants.o : $(FTOLPATH)/Source/Foundation/FTOLConstants.f90
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/Foundation/FTOLConstants.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/Foundation/FTOLConstants.f90
 
 FTSparseMatrixClass.o : $(FTOLPATH)/Source/FTObjects/FTSparseMatrixClass.f90 \
 FTLinkedListClass.o \
 FTObjectClass.o \
 FTLinkedListClass.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTSparseMatrixClass.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTSparseMatrixClass.f90
 
 FTStackClass.o : $(FTOLPATH)/Source/FTObjects/FTStackClass.f90 \
 FTLinkedListClass.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTStackClass.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTStackClass.f90
 
 FTStringSetClass.o : $(FTOLPATH)/Source/FTObjects/FTStringSetClass.f90 \
 FTObjectClass.o \
 FTDictionaryClass.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTStringSetClass.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTStringSetClass.f90
 
 FTValueClass.o : $(FTOLPATH)/Source/FTObjects/FTValueClass.f90 \
 FTOLConstants.o \
 FTObjectClass.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTValueClass.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTValueClass.f90
 
 FTValueDictionaryClass.o : $(FTOLPATH)/Source/FTObjects/FTValueDictionaryClass.f90 \
 FTValueClass.o \
 FTDictionaryClass.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTValueDictionaryClass.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTValueDictionaryClass.f90
 
 Geometry.o :$(HOHQMESHPATH)/Source/Foundation/Geometry.f90 \
 SMConstants.o \
 ProgramGlobals.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Foundation/Geometry.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Foundation/Geometry.f90
 
 Geometry3D.o :$(HOHQMESHPATH)/Source/3DSource/Geometry/Geometry3D.f90 \
 SMConstants.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/Geometry/Geometry3D.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/Geometry/Geometry3D.f90
 
 Hash.o : $(FTOLPATH)/Source/FTObjects/Hash.f90
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/Hash.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/Hash.f90
 
 HexMeshObjects.o :$(HOHQMESHPATH)/Source/3DSource/HexMeshObjects.f90 \
 SMConstants.o \
 SMMeshObjects.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/HexMeshObjects.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/HexMeshObjects.f90
 
 HOHQMeshMain.o :$(HOHQMESHPATH)/Source/HOHQMeshMain.f90 \
 HOHQMesh.o \
@@ -320,7 +320,7 @@ CommandLineReader.o \
 ProgramGlobals.o \
 MeshingTests.o \
 MeshQualityAnalysis.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/HOHQMeshMain.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/HOHQMeshMain.f90
 
 HOHQMesh.o :$(HOHQMESHPATH)/Source/HOHQMesh.f90 \
 MeshQualityAnalysis.o \
@@ -335,26 +335,26 @@ FTObjectArrayClass.o \
 MeshOutputMethods.o \
 3DMeshController.o \
 MeshGeneratorMethods.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/HOHQMesh.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/HOHQMesh.f90
 
 InterfaceElementMethods.o :$(HOHQMESHPATH)/Source/Mesh/InterfaceElementMethods.f90 \
 MeshProject.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Mesh/InterfaceElementMethods.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Mesh/InterfaceElementMethods.f90
 
 InterpolationAndDerivatives.o :$(HOHQMESHPATH)/Source/3DSource/Geometry/InterpolationAndDerivatives.f90 \
 SMConstants.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/Geometry/InterpolationAndDerivatives.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/Geometry/InterpolationAndDerivatives.f90
 
 LaplaceMeshSmoother.o :$(HOHQMESHPATH)/Source/Mesh/LaplaceMeshSmoother.f90 \
 Connections.o \
 MeshSmoother.o \
 SMModel.o \
 SMMeshClass.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Mesh/LaplaceMeshSmoother.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Mesh/LaplaceMeshSmoother.f90
 
 Mesh3DOutputMethods.o :$(HOHQMESHPATH)/Source/3DSource/Mesh3DOutputMethods.f90 \
 HexMeshObjects.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/Mesh3DOutputMethods.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/Mesh3DOutputMethods.f90
 
 MeshBoundaryMethods.o :$(HOHQMESHPATH)/Source/Mesh/MeshBoundaryMethods.f90 \
 CurveConversions.o \
@@ -368,7 +368,7 @@ SMMeshClass.o \
 fmin.o \
 Sizer.o \
 MeshOutputMethods.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Mesh/MeshBoundaryMethods.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Mesh/MeshBoundaryMethods.f90
 
 MeshCleaner.o :$(HOHQMESHPATH)/Source/Mesh/MeshCleaner.f90 \
 MeshQualityAnalysis.o \
@@ -382,7 +382,7 @@ SMMeshClass.o \
 fmin.o \
 Geometry.o \
 MeshBoundaryMethods.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Mesh/MeshCleaner.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Mesh/MeshCleaner.f90
 
 MeshGeneratorMethods.o :$(HOHQMESHPATH)/Source/Mesh/MeshGeneratorMethods.f90 \
 FatalErrorException.o \
@@ -399,7 +399,7 @@ MeshOperationsModule.o \
 MeshProject.o \
 fmin.o \
 MeshOutputMethods.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Mesh/MeshGeneratorMethods.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Mesh/MeshGeneratorMethods.f90
 
 MeshingTests.o :$(HOHQMESHPATH)/Source/Testing/MeshingTests.f90 \
 HOHQMesh.o \
@@ -409,7 +409,7 @@ TestSuiteManagerClass.o \
 Encoder.o \
 Assert.o \
 MeshQualityAnalysis.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Testing/MeshingTests.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Testing/MeshingTests.f90
 
 MeshOperationsModule.o :$(HOHQMESHPATH)/Source/Mesh/MeshOperationsModule.f90 \
 FTObjectClass.o \
@@ -420,7 +420,7 @@ SMMeshObjects.o \
 SMMeshClass.o \
 FTLinkedListClass.o \
 SMConstants.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Mesh/MeshOperationsModule.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Mesh/MeshOperationsModule.f90
 
 MeshOutputMethods.o :$(HOHQMESHPATH)/Source/IO/MeshOutputMethods.f90 \
 FTObjectArrayClass.o \
@@ -428,7 +428,7 @@ MeshOperationsModule.o \
 SMModel.o \
 SMMeshObjects.o \
 MeshQualityAnalysis.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/IO/MeshOutputMethods.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/IO/MeshOutputMethods.f90
 
 MeshProject.o :$(HOHQMESHPATH)/Source/Project/MeshProject.f90 \
 FTValueDictionaryClass.o \
@@ -449,31 +449,31 @@ FTExceptionClass.o \
 ChainedSegmentedCurveClass.o \
 SMConstants.o \
 SizerControls.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Project/MeshProject.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Project/MeshProject.f90
 
 MeshQualityAnalysis.o :$(HOHQMESHPATH)/Source/Mesh/MeshQualityAnalysis.f90 \
 SMMeshObjects.o \
 SMMeshClass.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Mesh/MeshQualityAnalysis.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Mesh/MeshQualityAnalysis.f90
 
 MeshSmoother.o :$(HOHQMESHPATH)/Source/Mesh/MeshSmoother.f90 \
 MeshBoundaryMethods.o \
 SMModel.o \
 SMMeshClass.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Mesh/MeshSmoother.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Mesh/MeshSmoother.f90
 
 Misc.o :$(HOHQMESHPATH)/Source/Foundation/Misc.f90
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Foundation/Misc.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Foundation/Misc.f90
 
 NodesTemplates.o :$(HOHQMESHPATH)/Source/QuadTreeGrid/NodesTemplates.f90 \
 ProgramGlobals.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/QuadTreeGrid/NodesTemplates.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/QuadTreeGrid/NodesTemplates.f90
 
 ObjectArrayAdditions.o :$(HOHQMESHPATH)/Source/Categories/ObjectArrayAdditions.f90 \
 FTObjectArrayClass.o \
 FTLinkedListClass.o \
 FTLinkedListClass.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Categories/ObjectArrayAdditions.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Categories/ObjectArrayAdditions.f90
 
 ParametricEquationCurveClass.o :$(HOHQMESHPATH)/Source/Curves/ContinuousCurves/ParametricEquationCurveClass.f90 \
 FTExceptionClass.o \
@@ -481,7 +481,7 @@ FTValueClass.o \
 SMConstants.o \
 EquationEvaluatorClass.o \
 SMCurveClass.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/ContinuousCurves/ParametricEquationCurveClass.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/ContinuousCurves/ParametricEquationCurveClass.f90
 
 ParametricEquationTopographyClass.o :$(HOHQMESHPATH)/Source/Surfaces/ParametricEquationTopographyClass.f90 \
 FTExceptionClass.o \
@@ -490,50 +490,50 @@ ProgramGlobals.o \
 SMConstants.o \
 EquationEvaluatorClass.o \
 SMTopographyClass.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Surfaces/ParametricEquationTopographyClass.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Surfaces/ParametricEquationTopographyClass.f90
 
 ProgramGlobals.o :$(HOHQMESHPATH)/Source/Foundation/ProgramGlobals.f90 \
 SMConstants.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Foundation/ProgramGlobals.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Foundation/ProgramGlobals.f90
 
 QuadTreeGridClass.o :$(HOHQMESHPATH)/Source/QuadTreeGrid/QuadTreeGridClass.f90 \
 Sizer.o \
 SMConstants.o \
 SMMeshObjects.o \
 FTObjectClass.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/QuadTreeGrid/QuadTreeGridClass.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/QuadTreeGrid/QuadTreeGridClass.f90
 
 QuadTreeGridGenerator.o :$(HOHQMESHPATH)/Source/QuadTreeGrid/QuadTreeGridGenerator.f90 \
 Sizer.o \
 QuadTreeGridClass.o \
 QuadTreeTemplateOperations.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/QuadTreeGrid/QuadTreeGridGenerator.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/QuadTreeGrid/QuadTreeGridGenerator.f90
 
 QuadTreeTemplateOperations.o :$(HOHQMESHPATH)/Source/QuadTreeGrid/QuadTreeTemplateOperations.f90 \
 QuadTreeGridClass.o \
 SMConstants.o \
 SMMeshObjects.o \
 Templates.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/QuadTreeGrid/QuadTreeTemplateOperations.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/QuadTreeGrid/QuadTreeTemplateOperations.f90
 
 ReaderExceptions.o :$(HOHQMESHPATH)/Source/3DSource/ReaderExceptions.f90 \
 FTExceptionClass.o \
 FTValueDictionaryClass.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/ReaderExceptions.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/ReaderExceptions.f90
 
 SegmentedCurveArrayClass.o :$(HOHQMESHPATH)/Source/Curves/DiscreteCurves/SegmentedCurveArrayClass.f90 \
 Geometry.o \
 ProgramGlobals.o \
 SMConstants.o \
 FTObjectClass.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/DiscreteCurves/SegmentedCurveArrayClass.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/DiscreteCurves/SegmentedCurveArrayClass.f90
 
 Shortcuts.o :$(HOHQMESHPATH)/Source/Foundation/Shortcuts.f90 \
 FTExceptionClass.o \
 FTValueDictionaryClass.o \
 FatalErrorException.o \
 SMConstants.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Foundation/Shortcuts.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Foundation/Shortcuts.f90
 
 SimpleSweep.o :$(HOHQMESHPATH)/Source/3DSource/SimpleSweep.f90 \
 FTExceptionClass.o \
@@ -546,7 +546,7 @@ MeshProject.o \
 SMMeshClass.o \
 SMConstants.o \
 ProgramGlobals.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/SimpleSweep.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/SimpleSweep.f90
 
 Sizer.o :$(HOHQMESHPATH)/Source/Project/Sizer/Sizer.f90 \
 SizerControls.o \
@@ -556,14 +556,14 @@ SMConstants.o \
 Geometry.o \
 FTLinkedListClass.o \
 FTLinkedListClass.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Project/Sizer/Sizer.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Project/Sizer/Sizer.f90
 
 SizerControls.o :$(HOHQMESHPATH)/Source/Project/Sizer/SizerControls.f90 \
 FTLinkedListClass.o \
 SMConstants.o \
 FTObjectClass.o \
 FTLinkedListClass.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Project/Sizer/SizerControls.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Project/Sizer/SizerControls.f90
 
 SMChainedCurveClass.o :$(HOHQMESHPATH)/Source/Curves/ContinuousCurves/SMChainedCurveClass.f90 \
 ProgramGlobals.o \
@@ -576,27 +576,27 @@ FTExceptionClass.o \
 FTObjectClass.o \
 FTLinkedListClass.o \
 FTLinkedListClass.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/ContinuousCurves/SMChainedCurveClass.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/ContinuousCurves/SMChainedCurveClass.f90
 
 SMCircularArc.o :$(HOHQMESHPATH)/Source/Curves/ContinuousCurves/SMCircularArc.f90 \
 SMCurveClass.o \
 SMConstants.o \
 ProgramGlobals.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/ContinuousCurves/SMCircularArc.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/ContinuousCurves/SMCircularArc.f90
 
 SMConstants.o :$(HOHQMESHPATH)/Source/Foundation/SMConstants.f90
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Foundation/SMConstants.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Foundation/SMConstants.f90
 
 SMCurveClass.o :$(HOHQMESHPATH)/Source/Curves/ContinuousCurves/SMCurveClass.f90 \
 ProgramGlobals.o \
 SMConstants.o \
 FTObjectClass.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/ContinuousCurves/SMCurveClass.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/ContinuousCurves/SMCurveClass.f90
 
 SMLine.o :$(HOHQMESHPATH)/Source/Curves/ContinuousCurves/SMLine.f90 \
 SMCurveClass.o \
 SMConstants.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/ContinuousCurves/SMLine.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/ContinuousCurves/SMLine.f90
 
 SMMeshClass.o :$(HOHQMESHPATH)/Source/Project/Mesh/SMMeshClass.f90 \
 SegmentedCurveArrayClass.o \
@@ -606,7 +606,7 @@ FTSparseMatrixClass.o \
 SMMeshObjects.o \
 FTObjectClass.o \
 FTLinkedListClass.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Project/Mesh/SMMeshClass.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Project/Mesh/SMMeshClass.f90
 
 SMMeshObjects.o :$(HOHQMESHPATH)/Source/MeshObjects/SMMeshObjects.f90 \
 FTObjectArrayClass.o \
@@ -614,7 +614,7 @@ ProgramGlobals.o \
 SMConstants.o \
 FTLinkedListClass.o \
 FTObjectClass.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/MeshObjects/SMMeshObjects.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/MeshObjects/SMMeshObjects.f90
 
 SMModel.o :$(HOHQMESHPATH)/Source/Project/Model/SMModel.f90 \
 SMLine.o \
@@ -636,18 +636,18 @@ FTDataClass.o \
 SMChainedCurveClass.o \
 ParametricEquationCurveClass.o \
 SMConstants.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Project/Model/SMModel.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Project/Model/SMModel.f90
 
 SMSplineCurveClass.o :$(HOHQMESHPATH)/Source/Curves/ContinuousCurves/SMSplineCurveClass.f90 \
 SMCurveClass.o \
 SMConstants.o \
 Geometry.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/ContinuousCurves/SMSplineCurveClass.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/ContinuousCurves/SMSplineCurveClass.f90
 
 SMTopographyClass.o :$(HOHQMESHPATH)/Source/Surfaces/SMTopographyClass.f90 \
 SMConstants.o \
 FTObjectClass.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Surfaces/SMTopographyClass.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Surfaces/SMTopographyClass.f90
 
 SpringMeshSmoother.o :$(HOHQMESHPATH)/Source/Mesh/SpringMeshSmoother.f90 \
 FatalErrorException.o \
@@ -656,7 +656,7 @@ MeshBoundaryMethods.o \
 SMModel.o \
 FTValueDictionaryClass.o \
 SMMeshClass.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Mesh/SpringMeshSmoother.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Mesh/SpringMeshSmoother.f90
 
 SweeperClass.o :$(HOHQMESHPATH)/Source/3DSource/SweeperClass.f90 \
 FTExceptionClass.o \
@@ -669,32 +669,32 @@ Geometry3D.o \
 Frenet.o \
 SMConstants.o \
 ProgramGlobals.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/SweeperClass.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/SweeperClass.f90
 
 Templates.o :$(HOHQMESHPATH)/Source/QuadTreeGrid/Templates.f90 \
 QuadTreeGridClass.o \
 SMConstants.o \
 SMMeshObjects.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/QuadTreeGrid/Templates.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/QuadTreeGrid/Templates.f90
 
 TestDataClass.o :$(HOHQMESHPATH)/Source/Testing/TestDataClass.f90 \
 SMConstants.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Testing/TestDataClass.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Testing/TestDataClass.f90
 
 TestSuiteManagerClass.o : $(FTOLPATH)/Source/FTTesting/TestSuiteManagerClass.f90 \
 Assert.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTTesting/TestSuiteManagerClass.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTTesting/TestSuiteManagerClass.f90
 
 TimerClass.o :$(HOHQMESHPATH)/Source/Foundation/TimerClass.f90
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Foundation/TimerClass.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Foundation/TimerClass.f90
 
 TransfiniteMapClass.o :$(HOHQMESHPATH)/Source/3DSource/Geometry/TransfiniteMapClass.f90 \
 CurveInterpolantClass.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/Geometry/TransfiniteMapClass.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/Geometry/TransfiniteMapClass.f90
 
 Utilities.o :$(HOHQMESHPATH)/Source/3DSource/Geometry/Utilities.f90 \
 SMConstants.o
-	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/Geometry/Utilities.f90
+	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/Geometry/Utilities.f90
 
 
 ###########

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ FC = gfortran
 HOHQMESHPATH = .
 FTOLPATH = $(HOHQMESHPATH)/Contrib/FTObjectLibrary
 
-FCFLAGS = -cpp -O
+FFLAGS = -cpp -O
 ##########################
 # Object Files for build #
 ##########################
@@ -112,12 +112,12 @@ HexMeshObjects.o \
 SMMeshObjects.o \
 FatalErrorException.o \
 MeshProject.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/3DMeshController.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/3DMeshController.f90
 
 Assert.o : $(FTOLPATH)/Source/FTTesting/Assert.f90 \
 Comparisons.o \
 FTOLConstants.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTTesting/Assert.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTTesting/Assert.f90
 
 BoundaryEdgeCleaning.o :$(HOHQMESHPATH)/Source/Mesh/BoundaryEdgeCleaning.f90 \
 Connections.o \
@@ -125,7 +125,7 @@ ProgramGlobals.o \
 MeshBoundaryMethods.o \
 SMModel.o \
 SMMeshClass.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Mesh/BoundaryEdgeCleaning.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Mesh/BoundaryEdgeCleaning.f90
 
 ChainedSegmentedCurveClass.o :$(HOHQMESHPATH)/Source/Curves/DiscreteCurves/ChainedSegmentedCurveClass.f90 \
 FTExceptionClass.o \
@@ -136,21 +136,21 @@ FTObjectArrayClass.o \
 FTDataClass.o \
 SMConstants.o \
 ProgramGlobals.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/DiscreteCurves/ChainedSegmentedCurveClass.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/DiscreteCurves/ChainedSegmentedCurveClass.f90
 
 CommandLineReader.o :$(HOHQMESHPATH)/Source/Foundation/CommandLineReader.f90
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Foundation/CommandLineReader.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Foundation/CommandLineReader.f90
 
 Comparisons.o : $(FTOLPATH)/Source/FTTesting/Comparisons.f90 \
 FTOLConstants.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTTesting/Comparisons.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTTesting/Comparisons.f90
 
 Connections.o :$(HOHQMESHPATH)/Source/Mesh/Connections.f90 \
 FTLinkedListClass.o \
 SMMeshObjects.o \
 MeshOutputMethods.o \
 SMMeshClass.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Mesh/Connections.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Mesh/Connections.f90
 
 ControlFileReader.o :$(HOHQMESHPATH)/Source/IO/ControlFileReader.f90 \
 FTExceptionClass.o \
@@ -162,18 +162,18 @@ FTValueDictionaryClass.o \
 FTStackClass.o \
 FTLinkedListClass.o \
 FTDataClass.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/IO/ControlFileReader.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/IO/ControlFileReader.f90
 
 CurveConversions.o :$(HOHQMESHPATH)/Source/Curves/DiscreteCurves/CurveConversions.f90 \
 ChainedSegmentedCurveClass.o \
 SizerControls.o \
 SegmentedCurveArrayClass.o \
 SMChainedCurveClass.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/DiscreteCurves/CurveConversions.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/DiscreteCurves/CurveConversions.f90
 
 CurveInterpolantClass.o :$(HOHQMESHPATH)/Source/3DSource/Geometry/CurveInterpolantClass.f90 \
 InterpolationAndDerivatives.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/Geometry/CurveInterpolantClass.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/Geometry/CurveInterpolantClass.f90
 
 CurveTests.o : $(HOHQMESHPATH)/Source/Testing/CurveTests.f90 \
 SMConstants.o \
@@ -186,37 +186,37 @@ TestSuiteManagerClass.o \
 Assert.o \
 SMSplineCurveClass.o \
 SMTopographyClass.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Testing/CurveTests.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Testing/CurveTests.f90
 
 ElementOperations.o :$(HOHQMESHPATH)/Source/MeshObjects/ElementOperations.f90 \
 SMMeshClass.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/MeshObjects/ElementOperations.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/MeshObjects/ElementOperations.f90
 
 Encoder.o :$(HOHQMESHPATH)/Source/Foundation/Encoder.f90
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Foundation/Encoder.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Foundation/Encoder.f90
 
 EquationEvaluatorClass.o :$(HOHQMESHPATH)/Source/Curves/ContinuousCurves/EquationEvaluatorClass.f90
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/ContinuousCurves/EquationEvaluatorClass.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/ContinuousCurves/EquationEvaluatorClass.f90
 
 FatalErrorException.o :$(HOHQMESHPATH)/Source/Foundation/FatalErrorException.f90 \
 FTExceptionClass.o \
 FTValueClass.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Foundation/FatalErrorException.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Foundation/FatalErrorException.f90
 
 FileAndStringProcessing.o :$(HOHQMESHPATH)/Source/IO/FileAndStringProcessing.f90 \
 SMConstants.o \
 ProgramGlobals.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/IO/FileAndStringProcessing.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/IO/FileAndStringProcessing.f90
 
 fmin.o :$(HOHQMESHPATH)/Source/Curves/fmin.f90 \
 SMCurveClass.o \
 ProgramGlobals.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/fmin.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/fmin.f90
 
 Frenet.o :$(HOHQMESHPATH)/Source/3DSource/Geometry/Frenet.f90 \
 SMCurveClass.o \
 Geometry3D.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/Geometry/Frenet.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/Geometry/Frenet.f90
 
 FRSegmentedCurveClass.o :$(HOHQMESHPATH)/Source/Curves/DiscreteCurves/FRSegmentedCurveClass.f90 \
 SMConstants.o \
@@ -230,11 +230,11 @@ ProgramGlobals.o \
 Geometry.o \
 ObjectArrayAdditions.o \
 FTLinkedListClass.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/DiscreteCurves/FRSegmentedCurveClass.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/DiscreteCurves/FRSegmentedCurveClass.f90
 
 FTDataClass.o : $(FTOLPATH)/Source/FTObjects/FTDataClass.f90 \
 FTObjectClass.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTDataClass.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTDataClass.f90
 
 FTDictionaryClass.o : $(FTOLPATH)/Source/FTObjects/FTDictionaryClass.f90 \
 FTObjectArrayClass.o \
@@ -242,76 +242,76 @@ FTLinkedListClass.o \
 FTObjectClass.o \
 FTLinkedListClass.o \
 Hash.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTDictionaryClass.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTDictionaryClass.f90
 
 FTExceptionClass.o : $(FTOLPATH)/Source/FTObjects/FTExceptionClass.f90 \
 FTDictionaryClass.o \
 FTValueDictionaryClass.o \
 FTStackClass.o \
 FTLinkedListClass.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTExceptionClass.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTExceptionClass.f90
 
 FTLinkedListClass.o : $(FTOLPATH)/Source/FTObjects/FTLinkedListClass.f90 \
 FTObjectArrayClass.o \
 FTObjectClass.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTLinkedListClass.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTLinkedListClass.f90
 
 FTMultiIndexTable.o : $(FTOLPATH)/Source/FTObjects/FTMultiIndexTable.f90 \
 FTObjectClass.o \
 FTLinkedListClass.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTMultiIndexTable.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTMultiIndexTable.f90
 
 FTObjectArrayClass.o : $(FTOLPATH)/Source/FTObjects/FTObjectArrayClass.f90 \
 FTObjectClass.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTObjectArrayClass.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTObjectArrayClass.f90
 
 FTObjectClass.o : $(FTOLPATH)/Source/FTObjects/FTObjectClass.f90
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTObjectClass.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTObjectClass.f90
 
 FTOLConstants.o : $(FTOLPATH)/Source/Foundation/FTOLConstants.f90
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/Foundation/FTOLConstants.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/Foundation/FTOLConstants.f90
 
 FTSparseMatrixClass.o : $(FTOLPATH)/Source/FTObjects/FTSparseMatrixClass.f90 \
 FTLinkedListClass.o \
 FTObjectClass.o \
 FTLinkedListClass.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTSparseMatrixClass.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTSparseMatrixClass.f90
 
 FTStackClass.o : $(FTOLPATH)/Source/FTObjects/FTStackClass.f90 \
 FTLinkedListClass.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTStackClass.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTStackClass.f90
 
 FTStringSetClass.o : $(FTOLPATH)/Source/FTObjects/FTStringSetClass.f90 \
 FTObjectClass.o \
 FTDictionaryClass.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTStringSetClass.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTStringSetClass.f90
 
 FTValueClass.o : $(FTOLPATH)/Source/FTObjects/FTValueClass.f90 \
 FTOLConstants.o \
 FTObjectClass.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTValueClass.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTValueClass.f90
 
 FTValueDictionaryClass.o : $(FTOLPATH)/Source/FTObjects/FTValueDictionaryClass.f90 \
 FTValueClass.o \
 FTDictionaryClass.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTValueDictionaryClass.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTValueDictionaryClass.f90
 
 Geometry.o :$(HOHQMESHPATH)/Source/Foundation/Geometry.f90 \
 SMConstants.o \
 ProgramGlobals.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Foundation/Geometry.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Foundation/Geometry.f90
 
 Geometry3D.o :$(HOHQMESHPATH)/Source/3DSource/Geometry/Geometry3D.f90 \
 SMConstants.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/Geometry/Geometry3D.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/Geometry/Geometry3D.f90
 
 Hash.o : $(FTOLPATH)/Source/FTObjects/Hash.f90
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/Hash.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/Hash.f90
 
 HexMeshObjects.o :$(HOHQMESHPATH)/Source/3DSource/HexMeshObjects.f90 \
 SMConstants.o \
 SMMeshObjects.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/HexMeshObjects.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/HexMeshObjects.f90
 
 HOHQMeshMain.o :$(HOHQMESHPATH)/Source/HOHQMeshMain.f90 \
 HOHQMesh.o \
@@ -320,7 +320,7 @@ CommandLineReader.o \
 ProgramGlobals.o \
 MeshingTests.o \
 MeshQualityAnalysis.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/HOHQMeshMain.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/HOHQMeshMain.f90
 
 HOHQMesh.o :$(HOHQMESHPATH)/Source/HOHQMesh.f90 \
 MeshQualityAnalysis.o \
@@ -335,26 +335,26 @@ FTObjectArrayClass.o \
 MeshOutputMethods.o \
 3DMeshController.o \
 MeshGeneratorMethods.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/HOHQMesh.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/HOHQMesh.f90
 
 InterfaceElementMethods.o :$(HOHQMESHPATH)/Source/Mesh/InterfaceElementMethods.f90 \
 MeshProject.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Mesh/InterfaceElementMethods.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Mesh/InterfaceElementMethods.f90
 
 InterpolationAndDerivatives.o :$(HOHQMESHPATH)/Source/3DSource/Geometry/InterpolationAndDerivatives.f90 \
 SMConstants.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/Geometry/InterpolationAndDerivatives.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/Geometry/InterpolationAndDerivatives.f90
 
 LaplaceMeshSmoother.o :$(HOHQMESHPATH)/Source/Mesh/LaplaceMeshSmoother.f90 \
 Connections.o \
 MeshSmoother.o \
 SMModel.o \
 SMMeshClass.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Mesh/LaplaceMeshSmoother.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Mesh/LaplaceMeshSmoother.f90
 
 Mesh3DOutputMethods.o :$(HOHQMESHPATH)/Source/3DSource/Mesh3DOutputMethods.f90 \
 HexMeshObjects.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/Mesh3DOutputMethods.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/Mesh3DOutputMethods.f90
 
 MeshBoundaryMethods.o :$(HOHQMESHPATH)/Source/Mesh/MeshBoundaryMethods.f90 \
 CurveConversions.o \
@@ -368,7 +368,7 @@ SMMeshClass.o \
 fmin.o \
 Sizer.o \
 MeshOutputMethods.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Mesh/MeshBoundaryMethods.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Mesh/MeshBoundaryMethods.f90
 
 MeshCleaner.o :$(HOHQMESHPATH)/Source/Mesh/MeshCleaner.f90 \
 MeshQualityAnalysis.o \
@@ -382,7 +382,7 @@ SMMeshClass.o \
 fmin.o \
 Geometry.o \
 MeshBoundaryMethods.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Mesh/MeshCleaner.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Mesh/MeshCleaner.f90
 
 MeshGeneratorMethods.o :$(HOHQMESHPATH)/Source/Mesh/MeshGeneratorMethods.f90 \
 FatalErrorException.o \
@@ -399,7 +399,7 @@ MeshOperationsModule.o \
 MeshProject.o \
 fmin.o \
 MeshOutputMethods.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Mesh/MeshGeneratorMethods.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Mesh/MeshGeneratorMethods.f90
 
 MeshingTests.o :$(HOHQMESHPATH)/Source/Testing/MeshingTests.f90 \
 HOHQMesh.o \
@@ -409,7 +409,7 @@ TestSuiteManagerClass.o \
 Encoder.o \
 Assert.o \
 MeshQualityAnalysis.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Testing/MeshingTests.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Testing/MeshingTests.f90
 
 MeshOperationsModule.o :$(HOHQMESHPATH)/Source/Mesh/MeshOperationsModule.f90 \
 FTObjectClass.o \
@@ -420,7 +420,7 @@ SMMeshObjects.o \
 SMMeshClass.o \
 FTLinkedListClass.o \
 SMConstants.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Mesh/MeshOperationsModule.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Mesh/MeshOperationsModule.f90
 
 MeshOutputMethods.o :$(HOHQMESHPATH)/Source/IO/MeshOutputMethods.f90 \
 FTObjectArrayClass.o \
@@ -428,7 +428,7 @@ MeshOperationsModule.o \
 SMModel.o \
 SMMeshObjects.o \
 MeshQualityAnalysis.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/IO/MeshOutputMethods.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/IO/MeshOutputMethods.f90
 
 MeshProject.o :$(HOHQMESHPATH)/Source/Project/MeshProject.f90 \
 FTValueDictionaryClass.o \
@@ -449,31 +449,31 @@ FTExceptionClass.o \
 ChainedSegmentedCurveClass.o \
 SMConstants.o \
 SizerControls.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Project/MeshProject.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Project/MeshProject.f90
 
 MeshQualityAnalysis.o :$(HOHQMESHPATH)/Source/Mesh/MeshQualityAnalysis.f90 \
 SMMeshObjects.o \
 SMMeshClass.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Mesh/MeshQualityAnalysis.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Mesh/MeshQualityAnalysis.f90
 
 MeshSmoother.o :$(HOHQMESHPATH)/Source/Mesh/MeshSmoother.f90 \
 MeshBoundaryMethods.o \
 SMModel.o \
 SMMeshClass.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Mesh/MeshSmoother.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Mesh/MeshSmoother.f90
 
 Misc.o :$(HOHQMESHPATH)/Source/Foundation/Misc.f90
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Foundation/Misc.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Foundation/Misc.f90
 
 NodesTemplates.o :$(HOHQMESHPATH)/Source/QuadTreeGrid/NodesTemplates.f90 \
 ProgramGlobals.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/QuadTreeGrid/NodesTemplates.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/QuadTreeGrid/NodesTemplates.f90
 
 ObjectArrayAdditions.o :$(HOHQMESHPATH)/Source/Categories/ObjectArrayAdditions.f90 \
 FTObjectArrayClass.o \
 FTLinkedListClass.o \
 FTLinkedListClass.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Categories/ObjectArrayAdditions.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Categories/ObjectArrayAdditions.f90
 
 ParametricEquationCurveClass.o :$(HOHQMESHPATH)/Source/Curves/ContinuousCurves/ParametricEquationCurveClass.f90 \
 FTExceptionClass.o \
@@ -481,7 +481,7 @@ FTValueClass.o \
 SMConstants.o \
 EquationEvaluatorClass.o \
 SMCurveClass.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/ContinuousCurves/ParametricEquationCurveClass.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/ContinuousCurves/ParametricEquationCurveClass.f90
 
 ParametricEquationTopographyClass.o :$(HOHQMESHPATH)/Source/Surfaces/ParametricEquationTopographyClass.f90 \
 FTExceptionClass.o \
@@ -490,50 +490,50 @@ ProgramGlobals.o \
 SMConstants.o \
 EquationEvaluatorClass.o \
 SMTopographyClass.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Surfaces/ParametricEquationTopographyClass.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Surfaces/ParametricEquationTopographyClass.f90
 
 ProgramGlobals.o :$(HOHQMESHPATH)/Source/Foundation/ProgramGlobals.f90 \
 SMConstants.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Foundation/ProgramGlobals.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Foundation/ProgramGlobals.f90
 
 QuadTreeGridClass.o :$(HOHQMESHPATH)/Source/QuadTreeGrid/QuadTreeGridClass.f90 \
 Sizer.o \
 SMConstants.o \
 SMMeshObjects.o \
 FTObjectClass.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/QuadTreeGrid/QuadTreeGridClass.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/QuadTreeGrid/QuadTreeGridClass.f90
 
 QuadTreeGridGenerator.o :$(HOHQMESHPATH)/Source/QuadTreeGrid/QuadTreeGridGenerator.f90 \
 Sizer.o \
 QuadTreeGridClass.o \
 QuadTreeTemplateOperations.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/QuadTreeGrid/QuadTreeGridGenerator.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/QuadTreeGrid/QuadTreeGridGenerator.f90
 
 QuadTreeTemplateOperations.o :$(HOHQMESHPATH)/Source/QuadTreeGrid/QuadTreeTemplateOperations.f90 \
 QuadTreeGridClass.o \
 SMConstants.o \
 SMMeshObjects.o \
 Templates.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/QuadTreeGrid/QuadTreeTemplateOperations.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/QuadTreeGrid/QuadTreeTemplateOperations.f90
 
 ReaderExceptions.o :$(HOHQMESHPATH)/Source/3DSource/ReaderExceptions.f90 \
 FTExceptionClass.o \
 FTValueDictionaryClass.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/ReaderExceptions.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/ReaderExceptions.f90
 
 SegmentedCurveArrayClass.o :$(HOHQMESHPATH)/Source/Curves/DiscreteCurves/SegmentedCurveArrayClass.f90 \
 Geometry.o \
 ProgramGlobals.o \
 SMConstants.o \
 FTObjectClass.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/DiscreteCurves/SegmentedCurveArrayClass.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/DiscreteCurves/SegmentedCurveArrayClass.f90
 
 Shortcuts.o :$(HOHQMESHPATH)/Source/Foundation/Shortcuts.f90 \
 FTExceptionClass.o \
 FTValueDictionaryClass.o \
 FatalErrorException.o \
 SMConstants.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Foundation/Shortcuts.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Foundation/Shortcuts.f90
 
 SimpleSweep.o :$(HOHQMESHPATH)/Source/3DSource/SimpleSweep.f90 \
 FTExceptionClass.o \
@@ -546,7 +546,7 @@ MeshProject.o \
 SMMeshClass.o \
 SMConstants.o \
 ProgramGlobals.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/SimpleSweep.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/SimpleSweep.f90
 
 Sizer.o :$(HOHQMESHPATH)/Source/Project/Sizer/Sizer.f90 \
 SizerControls.o \
@@ -556,14 +556,14 @@ SMConstants.o \
 Geometry.o \
 FTLinkedListClass.o \
 FTLinkedListClass.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Project/Sizer/Sizer.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Project/Sizer/Sizer.f90
 
 SizerControls.o :$(HOHQMESHPATH)/Source/Project/Sizer/SizerControls.f90 \
 FTLinkedListClass.o \
 SMConstants.o \
 FTObjectClass.o \
 FTLinkedListClass.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Project/Sizer/SizerControls.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Project/Sizer/SizerControls.f90
 
 SMChainedCurveClass.o :$(HOHQMESHPATH)/Source/Curves/ContinuousCurves/SMChainedCurveClass.f90 \
 ProgramGlobals.o \
@@ -576,27 +576,27 @@ FTExceptionClass.o \
 FTObjectClass.o \
 FTLinkedListClass.o \
 FTLinkedListClass.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/ContinuousCurves/SMChainedCurveClass.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/ContinuousCurves/SMChainedCurveClass.f90
 
 SMCircularArc.o :$(HOHQMESHPATH)/Source/Curves/ContinuousCurves/SMCircularArc.f90 \
 SMCurveClass.o \
 SMConstants.o \
 ProgramGlobals.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/ContinuousCurves/SMCircularArc.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/ContinuousCurves/SMCircularArc.f90
 
 SMConstants.o :$(HOHQMESHPATH)/Source/Foundation/SMConstants.f90
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Foundation/SMConstants.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Foundation/SMConstants.f90
 
 SMCurveClass.o :$(HOHQMESHPATH)/Source/Curves/ContinuousCurves/SMCurveClass.f90 \
 ProgramGlobals.o \
 SMConstants.o \
 FTObjectClass.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/ContinuousCurves/SMCurveClass.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/ContinuousCurves/SMCurveClass.f90
 
 SMLine.o :$(HOHQMESHPATH)/Source/Curves/ContinuousCurves/SMLine.f90 \
 SMCurveClass.o \
 SMConstants.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/ContinuousCurves/SMLine.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/ContinuousCurves/SMLine.f90
 
 SMMeshClass.o :$(HOHQMESHPATH)/Source/Project/Mesh/SMMeshClass.f90 \
 SegmentedCurveArrayClass.o \
@@ -606,7 +606,7 @@ FTSparseMatrixClass.o \
 SMMeshObjects.o \
 FTObjectClass.o \
 FTLinkedListClass.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Project/Mesh/SMMeshClass.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Project/Mesh/SMMeshClass.f90
 
 SMMeshObjects.o :$(HOHQMESHPATH)/Source/MeshObjects/SMMeshObjects.f90 \
 FTObjectArrayClass.o \
@@ -614,7 +614,7 @@ ProgramGlobals.o \
 SMConstants.o \
 FTLinkedListClass.o \
 FTObjectClass.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/MeshObjects/SMMeshObjects.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/MeshObjects/SMMeshObjects.f90
 
 SMModel.o :$(HOHQMESHPATH)/Source/Project/Model/SMModel.f90 \
 SMLine.o \
@@ -636,18 +636,18 @@ FTDataClass.o \
 SMChainedCurveClass.o \
 ParametricEquationCurveClass.o \
 SMConstants.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Project/Model/SMModel.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Project/Model/SMModel.f90
 
 SMSplineCurveClass.o :$(HOHQMESHPATH)/Source/Curves/ContinuousCurves/SMSplineCurveClass.f90 \
 SMCurveClass.o \
 SMConstants.o \
 Geometry.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/ContinuousCurves/SMSplineCurveClass.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Curves/ContinuousCurves/SMSplineCurveClass.f90
 
 SMTopographyClass.o :$(HOHQMESHPATH)/Source/Surfaces/SMTopographyClass.f90 \
 SMConstants.o \
 FTObjectClass.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Surfaces/SMTopographyClass.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Surfaces/SMTopographyClass.f90
 
 SpringMeshSmoother.o :$(HOHQMESHPATH)/Source/Mesh/SpringMeshSmoother.f90 \
 FatalErrorException.o \
@@ -656,7 +656,7 @@ MeshBoundaryMethods.o \
 SMModel.o \
 FTValueDictionaryClass.o \
 SMMeshClass.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Mesh/SpringMeshSmoother.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Mesh/SpringMeshSmoother.f90
 
 SweeperClass.o :$(HOHQMESHPATH)/Source/3DSource/SweeperClass.f90 \
 FTExceptionClass.o \
@@ -669,32 +669,32 @@ Geometry3D.o \
 Frenet.o \
 SMConstants.o \
 ProgramGlobals.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/SweeperClass.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/SweeperClass.f90
 
 Templates.o :$(HOHQMESHPATH)/Source/QuadTreeGrid/Templates.f90 \
 QuadTreeGridClass.o \
 SMConstants.o \
 SMMeshObjects.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/QuadTreeGrid/Templates.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/QuadTreeGrid/Templates.f90
 
 TestDataClass.o :$(HOHQMESHPATH)/Source/Testing/TestDataClass.f90 \
 SMConstants.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Testing/TestDataClass.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Testing/TestDataClass.f90
 
 TestSuiteManagerClass.o : $(FTOLPATH)/Source/FTTesting/TestSuiteManagerClass.f90 \
 Assert.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTTesting/TestSuiteManagerClass.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTTesting/TestSuiteManagerClass.f90
 
 TimerClass.o :$(HOHQMESHPATH)/Source/Foundation/TimerClass.f90
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Foundation/TimerClass.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/Foundation/TimerClass.f90
 
 TransfiniteMapClass.o :$(HOHQMESHPATH)/Source/3DSource/Geometry/TransfiniteMapClass.f90 \
 CurveInterpolantClass.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/Geometry/TransfiniteMapClass.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/Geometry/TransfiniteMapClass.f90
 
 Utilities.o :$(HOHQMESHPATH)/Source/3DSource/Geometry/Utilities.f90 \
 SMConstants.o
-	$(FC) -c $(FCFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/Geometry/Utilities.f90
+	$(FC) -c $(FFLAGS) $(INCLUDES) -o $@ $(HOHQMESHPATH)/Source/3DSource/Geometry/Utilities.f90
 
 
 ###########

--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,8 @@ FTDictionaryClass.o : $(FTOLPATH)/Source/FTObjects/FTDictionaryClass.f90 \
 FTObjectArrayClass.o \
 FTLinkedListClass.o \
 FTObjectClass.o \
-FTLinkedListClass.o
+FTLinkedListClass.o \
+Hash.o
 	$(F90) -c $(FFLAGS) $(INCLUDES) -o $@ $(FTOLPATH)/Source/FTObjects/FTDictionaryClass.f90
 
 FTExceptionClass.o : $(FTOLPATH)/Source/FTObjects/FTExceptionClass.f90 \

--- a/README.md
+++ b/README.md
@@ -9,24 +9,57 @@
   <img width="400px" src="https://user-images.githubusercontent.com/3637659/121870408-50418800-cd03-11eb-9187-dcafdf73bab2.png" />
 </p>
 
-## Installation
-To build, edit the `Makefile` file as indicated in the header and move to
-ones favorite directory. Type
+## Getting started
+
+## Obtaining the sources
+You can download the
+[latest HOHQMesh release](https://github.com/trixi-framework/HOHQMesh/releases/latest)
+from GitHub. Make sure to get the tarball named `HOHQMesh-vVERSION.tar.gz`, as
+it already contains the required sources for the
+[FTObjectLibrary](https://github.com/trixi-framework/FTObjectLibrary)
+dependency, and unpack it with `tar xf HOHQMesh-vVERSION.tar.gz`.
+Alternatively, you can build HOHQMesh directly from the latest sources in the
+`main` branch. In this case, you need enter the clone directory and execute
+```bash
+./Utilities/bootstrap
+```
+before proceeding, which will download the `FTObjectLibrary` sources for you.
+This step is required only once.
+
+## Building
+Enter the HOHQMesh directory and execute
 ```shell
 make
 ```
-That will build HOHQMesh.
+This will build HOHQMesh using the `gfortran` compiler by default.
+The compiler choice can be overriden by passing `FC=<pathToCompiler>` to
+`make`.
+You can further pass the `-jN` option to `make` (with `N` being a non-negative
+integer), which will use `N` parallel processes.
 
-To run the tests, type
+For example, to build HOHQMesh specifically with the Fortran compiler
+`gfortran-10` and with 4 parallel processes, execute
+```bash
+make -j 4 FC=gfortran-10
+```
+
+## Testing
+After building HOHQMesh, you can verify that everything works as expected by
+running the internal test suite. To execute the tests, type
 ```bash
 ./HOHQMesh -test -path <pathToBenchmarks>
 ```
-where `<pathToBenchmarks>` is the path to the HOHQMesh directory.
+where `<pathToBenchmarks>` is the path to the HOHQMesh directory. If you are
+inside the HOHQMesh directory, you can also omit the `-path` option, as it
+defaults to `.`.
 
+## Generating a mesh
 To mesh a control file, type
 ```bash
 ./HOHQMesh -f <pathToControlFile>
 ```
+where `-f` allows you to provide the path to the control file for which you want
+to create your mesh.
 
 ## Authors
 HOHQMesh was initiated by

--- a/Utilities/createcoverage
+++ b/Utilities/createcoverage
@@ -7,7 +7,7 @@ set -eox pipefail
 make clean
 
 # Build test suite
-make -j 2 F90=$F90 FFLAGS="-cpp --coverage -O0" LDFLAGS="--coverage"
+make -j 2 FC=$FC FFLAGS="-cpp --coverage -O0" LDFLAGS="--coverage"
 
 # Reset counters
 lcov --directory . --exclude '*/FTObjectLibrary/*' --zerocounters

--- a/Utilities/testrelease
+++ b/Utilities/testrelease
@@ -30,10 +30,10 @@ cd "$tmpdir"/HOHQMesh-*
 
 # Build HOHQMesh
 printf "Build HOHQMesh... "
-if [ -z "$F90" ]; then
+if [ -z "$FC" ]; then
   make -j 2 -s
 else
-  make -j 2 -s F90=$F90
+  make -j 2 -s FC=$FC
 fi
 echo "OK"
 


### PR DESCRIPTION
This fixes the Makefile, which had a missing dependency on `Hash.o` for `FTDictionaryClass.o` (thanks @andrewwinters5000 for being our canary here!).

Further, this updates the README to actually work when directly building the sources from the GitHub repo.

Finally, I changed the Fortran compiler environment variable from `F90` to `FC` in the Makefile, since `FC` is the standard variable name for the Fortran compiler for both [automake](https://www.gnu.org/software/automake/manual/html_node/Fortran-9x-Support.html) and [CMake](https://cmake.org/cmake/help/v3.20/envvar/FC.html).