### PR TITLE
Update MeshingTests.f90

### DIFF
--- a/Benchmarks/BenchmarkFiles.txt
+++ b/Benchmarks/BenchmarkFiles.txt
@@ -1,0 +1,15 @@
+Benchmarks/ControlFiles/PillC.control                
+Benchmarks/ControlFiles/SplineGeometry.control       
+Benchmarks/ControlFiles/SplineGeometryF.control      
+Benchmarks/ControlFiles/NACA0012.control             
+Benchmarks/ControlFiles/HalfCircleArc.control        
+Benchmarks/ControlFiles/Circles3.control             
+Benchmarks/ControlFiles/AllFeatures.control          
+Benchmarks/ControlFiles/Segmented.control            
+Benchmarks/ControlFiles/GingerbreadManGeometry.control
+Benchmarks/ControlFiles/sigmoidScale.control         
+Benchmarks/ControlFiles/HalfCircle3DRot.control      
+Benchmarks/ControlFiles/HalfCircleExtrude.control    
+Benchmarks/ControlFiles/Pond.control                 
+Benchmarks/ControlFiles/BottomFromFile.control       
+Benchmarks/ControlFiles/ABAQUS_IceCreamCone.control

--- a/Documentation/docs/adding-a-new-test.md
+++ b/Documentation/docs/adding-a-new-test.md
@@ -16,10 +16,12 @@ procedure:
    ./HOHQMesh -generateTest -f Benchmarks/ControlFiles/NewTestMesh.control
    ```
    This will write the test benchmark file to the location requested in the previous step.
-4. Go to line 58 in `Source/Testing/MeshingTest.f90` and add the new control file path to the list of test cases, e.g.,
-   Don't forget to change the `DIMENSION` of this list accordingly.
+4. Open the file `/Benchmarks/BenchmarkFiles.txt` and add the new control file path to the list of test cases, e.g.,
+   ```
+   Benchmarks/ControlFiles/NewTestMesh.control
+   ```
 
-After this procedure, recompile HOHQMesh. To execute the tests locally type
+To execute the tests locally type
 ```
 ./HOHQMesh -test -path <pathToBenchmarks>
 ```

--- a/Source/Testing/MeshingTests.f90
+++ b/Source/Testing/MeshingTests.f90
@@ -106,14 +106,14 @@
 !     --------------------------------
 !
       path = pathToTestFiles
-      
+
       IF ( TRIM(path) == "" )     THEN
-         fullPath =  "BenchMarks/BenchmarkFiles.txt"
+         fullPath =  "Benchmarks/BenchmarkFiles.txt"
       ELSE
          CALL ConvertToPath(path)
-         fullPath = TRIM(path) // "BenchMarks/BenchmarkFiles.txt"
+         fullPath = TRIM(path) // "Benchmarks/BenchmarkFiles.txt"
       END IF
-      
+
       INQUIRE( FILE = fullPath, EXIST = exst )
       IF (.NOT.exst) THEN
          WRITE(msg, *) "Unable to open the list of test files: " // TRIM(ADJUSTL(fullPath))
@@ -122,7 +122,7 @@
                                         typ    = FT_ERROR_FATAL)
          RETURN
       END IF
-      
+
       OPEN(NEWUNIT = fUnit, FILE = fullPath)
 !
 !     -------------------------
@@ -130,11 +130,11 @@
 !     -------------------------
 !
       nControlFiles = 0
-      
+
       DO
          READ(UNIT = fUnit, FMT = '(A)', END = 1000) str
          nControlFiles = nControlFiles + 1
-      END DO 
+      END DO
 1000  CONTINUE
 
       ALLOCATE(controlFiles(nControlFiles))
@@ -144,10 +144,10 @@
 !     Read in the control file names
 !     ------------------------------
 !
-      DO k = 1, nControlFiles 
+      DO k = 1, nControlFiles
          READ(UNIT = fUnit, FMT = '(A)') str
          controlFiles(k) = TRIM(str)
-      END DO 
+      END DO
 !
 !     -------------------------------------
 !     Add the tests of meshes to test suite


### PR DESCRIPTION
Take the test file names from a file. Reads through the file to count the number of tests, allocates, then reads again. This should help avoid collisions when merging due to the need to change the code when adding new tests.