### PR TITLE
Implement subdivision check

### DIFF
--- a/Source/Curves/DiscreteCurves/ChainedSegmentedCurveClass.f90
+++ b/Source/Curves/DiscreteCurves/ChainedSegmentedCurveClass.f90
@@ -86,6 +86,7 @@
          PROCEDURE :: nodeCount         => numberOfNodesInChain
          PROCEDURE :: complete          => completeChainedSegmentedCurve
          PROCEDURE :: positionAtIndex   => positionAtChainIndex
+         PROCEDURE :: maxInverseScale
          PROCEDURE :: segmentedCurveAtIndex
          PROCEDURE :: chainNumberForIndex
          PROCEDURE :: localIndexForChainIndexInCurveNumber
@@ -558,6 +559,28 @@
          self % boundingBox(BBOX_RIGHT)  = xMax
          
       END SUBROUTINE ComputeBoundingBox 
+!
+!////////////////////////////////////////////////////////////////////////
+!
+      REAL(KIND=RP) FUNCTION maxInverseScale( self )
+         IMPLICIT NONE
+         
+         CLASS(ChainedSegmentedCurve)     :: self
+         
+         CLASS(FRSegmentedCurve), POINTER :: c => NULL()
+         REAL(KIND=RP)                    :: xMin, xMax, yMin, yMax, x(3)
+         INTEGER                          :: j, k
+         
+         maxInverseScale = TINY(maxInverseScale)
+         
+         DO k = 1, self % numberOfCurvesInChain
+            c => self % segmentedCurveAtIndex(k)
+            DO j = 1, c % COUNT()
+               maxInverseScale = MAX(maxInverseScale, c % invScaleAtIndex(j)) 
+            END DO  
+         END DO  
+         
+      END FUNCTION maxInverseScale 
 !
 !////////////////////////////////////////////////////////////////////////
 !

--- a/Source/Foundation/ProgramGlobals.f90
+++ b/Source/Foundation/ProgramGlobals.f90
@@ -114,6 +114,7 @@
          REAL(KIND=RP) :: directionPenalty        = 1.0d-4
          REAL(KIND=RP) :: boundingBoxOverlapTol   = 1.0d-5
          LOGICAL       :: boundarySlipping        = .FALSE.
+         INTEGER       :: maxLevelLimit           = 8      ! allow at most maxLevelLimit levels of subdivision
 !
 !        --------------------
 !        For printing history

--- a/Source/HOHQMesh.f90
+++ b/Source/HOHQMesh.f90
@@ -141,10 +141,11 @@
             PRINT *, "*******************"
             PRINT *, "2D Mesh Statistics:"
             PRINT *, "*******************"
-            PRINT *, "   Total time         = ", stopWatch % elapsedTime(TC_SECONDS)
-            PRINT *, "   Number of nodes    = ", project % mesh % nodes    % COUNT()
-            PRINT *, "   Number of Edges    = ", project % mesh % edges    % COUNT()
-            PRINT *, "   Number of Elements = ", project % mesh % elements % COUNT()
+            PRINT *, "   Total time             = ", stopWatch % elapsedTime(TC_SECONDS)
+            PRINT *, "   Number of nodes        = ", project % mesh % nodes    % COUNT()
+            PRINT *, "   Number of Edges        = ", project % mesh % edges    % COUNT()
+            PRINT *, "   Number of Elements     = ", project % mesh % elements % COUNT()
+            PRINT *, "   Number of Subdivisions = ", project % numberOfLevelsUsed
          END IF
 !
 !        ---------------------------------

--- a/Source/HOHQMeshMain.f90
+++ b/Source/HOHQMeshMain.f90
@@ -198,4 +198,8 @@
             path = StringValueForArgument(argument = "-path")
          END IF
 
+         IF ( CommandLineArgumentIsPresent(argument = "-sLimit") )     THEN
+            maxLevelLimit = IntegerValueForArgument(argument = "-sLimit")
+         END IF
+
       END SUBROUTINE ReadCommandLineArguments

--- a/Source/Mesh/MeshGeneratorMethods.f90
+++ b/Source/Mesh/MeshGeneratorMethods.f90
@@ -216,6 +216,7 @@
          CALL GenerateGridWithSizerAndType( project % grid, project % sizer, &
                                             project % meshParams % meshType)
          project % numberOfLevelsUsed = highestLevel
+         IF(catch() .AND. (maximumErrorSeverity() == FT_ERROR_FATAL)) RETURN 
       IF(PrintMessage) PRINT *, "   Quadtree grid generated"
 !
 !     ---------------

--- a/Source/Mesh/MeshGeneratorMethods.f90
+++ b/Source/Mesh/MeshGeneratorMethods.f90
@@ -215,6 +215,7 @@
       IF(PrintMessage) PRINT *, "   Generate quadtree..."
          CALL GenerateGridWithSizerAndType( project % grid, project % sizer, &
                                             project % meshParams % meshType)
+         project % numberOfLevelsUsed = highestLevel
       IF(PrintMessage) PRINT *, "   Quadtree grid generated"
 !
 !     ---------------

--- a/Source/Project/Sizer/Sizer.f90
+++ b/Source/Project/Sizer/Sizer.f90
@@ -1120,7 +1120,7 @@
 !     background grid size to the smallest size inferred by the local 
 !     curvatures. The log_2(Ratio) gives the number of subdivsions that
 !     would be needed (locally) to size the mesh. The routine also
-!     returns the name of the curve with the smallest radius of curvature, so that
+!     returns the name of the curve with the smallest implied scale, so that
 !     can be reported to the user, if desired.
 !     ----------------------------------------------------------------------------
 !      

--- a/Source/QuadTreeGrid/QuadTreeGridClass.f90
+++ b/Source/QuadTreeGrid/QuadTreeGridClass.f90
@@ -468,7 +468,8 @@
             CALL GetGridPosition( self % x0, self % dx, i  , j  , xMax )
             hMin = sizeFunctionMinimumOnBox( sizer, xMin, xMax )
             
-            IF ( hMin - MAXVAL(self % dx(1:2)) < -subdivisionRelTol*MAXVAL(self % dx(1:2)) )     THEN ! This quad is too big.
+            IF ( hMin - MAXVAL(self % dx(1:2)) < -subdivisionRelTol*MAXVAL(self % dx(1:2)) .AND. &
+                 highestLevel < maxLevelLimit )     THEN ! This quad is too big.
             
                dx = self % dx/DBLE(refinementType)
                ALLOCATE(childGrid)

--- a/Source/QuadTreeGrid/QuadTreeGridClass.f90
+++ b/Source/QuadTreeGrid/QuadTreeGridClass.f90
@@ -114,7 +114,7 @@
       INTEGER  :: highestLevel    = 0
       INTEGER  :: globalNodeCount = 0
       INTEGER  :: globalGridCount = 0
-      
+       
       INTEGER                                                :: numberOfGridsAtLevel
       TYPE(NestedQuadTreeGridPtr), DIMENSION(:), ALLOCATABLE :: gridsAtLevel
 !
@@ -445,10 +445,13 @@
       INTEGER                      :: N(3) = 3
       REAL(KIND=RP)                :: hMin, xMin(3), xMax(3), dX(3)
       CLASS(QuadTreeGrid), POINTER :: childGrid
+      CHARACTER(LEN=256)           :: limitMsg
+      CHARACTER(LEN=32)            :: xMinAsString
 !
       N  = refinementType
       nX = self % N(1)
       nY = self % N(2)
+      IF(catch() .AND. (maximumErrorSeverity() == FT_ERROR_FATAL)) RETURN 
 !
 !     ----------------
 !     Do for each quad
@@ -468,18 +471,31 @@
             CALL GetGridPosition( self % x0, self % dx, i  , j  , xMax )
             hMin = sizeFunctionMinimumOnBox( sizer, xMin, xMax )
             
-            IF ( hMin - MAXVAL(self % dx(1:2)) < -subdivisionRelTol*MAXVAL(self % dx(1:2)) .AND. &
-                 highestLevel < maxLevelLimit )     THEN ! This quad is too big.
+            IF ( hMin - MAXVAL(self % dx(1:2)) < -subdivisionRelTol*MAXVAL(self % dx(1:2)))     THEN
             
-               dx = self % dx/DBLE(refinementType)
-               ALLOCATE(childGrid)
-               CALL childGrid % initGridWithParameters( dx, xMin, N, self, (/i,j,0/), self % level+1)
-               self % children(i,j) % grid => childGrid
-               CALL SetNeighborPointers( childGrid )
+               IF ( highestLevel < maxLevelLimit )     THEN
                
-               CALL RefineGrid_ToSizeFunction_( childGrid, sizer )
+                  dx = self % dx/DBLE(refinementType)
+                  ALLOCATE(childGrid)
+                  CALL childGrid % initGridWithParameters( dx, xMin, N, self, (/i,j,0/), self % level+1)
+                  self % children(i,j) % grid => childGrid
+                  CALL SetNeighborPointers( childGrid )
+                  
+                  CALL RefineGrid_ToSizeFunction_( childGrid, sizer )
+                  
+                  highestLevel = MAX( highestLevel, self % level+1 )
+                  
+               ELSE 
                
-               highestLevel = MAX( highestLevel, self % level+1 )
+                  WRITE(xMinAsString, '(F7.2,1x,F7.2)') xMin(1), xMin(2)
+                  limitMsg = "Resolution near " // xMinAsString // " needs more subdivisions than the currently allowed. " //&
+                              "To override, rerun with the command line flag '-sLimit'. But think before doing this."
+                                                
+                  CALL ThrowErrorExceptionOfType(poster = "RefineGrid_ToSizeFunction_", &
+                                                 msg    = limitMsg,       &
+                                                 typ    = FT_ERROR_FATAL)
+                  RETURN 
+               END IF 
                
             END IF
             

--- a/Source/QuadTreeGrid/QuadTreeGridGenerator.f90
+++ b/Source/QuadTreeGrid/QuadTreeGridGenerator.f90
@@ -104,6 +104,7 @@
       CLASS(MeshSizer)             :: sizer
       
       CALL generateNonconformingQuadTree(grid = grid,sizer = sizer)
+      IF(catch() .AND. (maximumErrorSeverity() == FT_ERROR_FATAL)) RETURN 
       CALL ConstructQuads( grid )
       
       END SUBROUTINE GenerateNCGridWithSizer
@@ -121,6 +122,7 @@
       CLASS(MeshSizer)             :: sizer
       
       CALL generateNonconformingQuadTree(grid = grid,sizer = sizer)
+      IF(catch() .AND. (maximumErrorSeverity() == FT_ERROR_FATAL)) RETURN 
       CALL DoLevelOperation( grid, REMOVE_HANGING_NODES_OPERATION )
       CALL DeleteDuplicateNodesForGrid( grid )
       CALL ConstructQuadsWithTemplates( grid )
@@ -141,6 +143,7 @@
          INTEGER :: k
       
          CALL RefineGrid_ToSizeFunction_( grid, sizer )
+         IF(catch() .AND. (maximumErrorSeverity() == FT_ERROR_FATAL)) RETURN 
          CALL DeleteDuplicateNodesForGrid( grid )
          
          IF( refinementType == REFINEMENT_2 )     THEN


### PR DESCRIPTION
Finds the number of refinements necessary to resolve boundary curves. If that number is larger than maxLevelLimit (currently 8, for a size ratio of 256) then a fatal error is posted with a message to rerun with the sLimit flag. Plus a warning to think before doing it. No auto testing for this feature is added yet.