### PR TITLE
Fix Windows CI errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,13 +53,7 @@ jobs:
         with:
           update: true
           # install: git base-devel mingw-w64-x86_64-toolchain
-          install: git base-devel
-      - name: Install gfortran-11 on Windows
-        if: ${{ matrix.os == 'windows-latest' }}
-        run: |
-          pacman -U https://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-libs-11.3.0-1-any.pkg.tar.zst
-          pacman -U https://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-libgfortran-11.3.0-1-any.pkg.tar.zst
-          pacman -U https://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-fortran-11.3.0-1-any.pkg.tar.zst
+          install: git base-devel gcc-fortran
       - name: Bootstrap
         run: |
           ./Utilities/bootstrap

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,12 @@ jobs:
         if: ${{ matrix.os == 'windows-latest' }}
         with:
           update: true
-          install: git base-devel mingw-w64-x86_64-toolchain
+          # install: git base-devel mingw-w64-x86_64-toolchain
+          install: git base-devel
+      - name: Install gfortran-11 on Windows
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: |
+          pacman -U https://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-fortran-11.3.0-1-any.pkg.tar.zst
       - name: Bootstrap
         run: |
           ./Utilities/bootstrap

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
         with:
           update: true
           # install: git base-devel mingw-w64-x86_64-toolchain
+          # Need to use `gcc-fortran` which provides gfortran v11, since the newer mingw toolchain
+          # uses gfortran v12 that causes segfaults, see https://github.com/trixi-framework/HOHQMesh/pull/39
           install: git base-devel gcc-fortran
       - name: Bootstrap
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           - os: macos-latest
             compiler: gfortran-10
             shell: bash
-          - os: windows-2019
+          - os: windows-latest
             compiler: gfortran
             shell: 'msys2 {0}'
     # Set default shell as suggested here: https://github.community/t/setting-default-shell-or-other-step-metadata-conditionally-in-workflows/154055

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,8 @@ jobs:
       - name: Install gfortran-11 on Windows
         if: ${{ matrix.os == 'windows-latest' }}
         run: |
+          pacman -U https://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-libs-11.3.0-1-any.pkg.tar.zst
+          pacman -U https://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-libgfortran-11.3.0-1-any.pkg.tar.zst
           pacman -U https://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-fortran-11.3.0-1-any.pkg.tar.zst
       - name: Bootstrap
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           - os: macos-latest
             compiler: gfortran-10
             shell: bash
-          - os: windows-latest
+          - os: windows-2019
             compiler: gfortran
             shell: 'msys2 {0}'
     # Set default shell as suggested here: https://github.community/t/setting-default-shell-or-other-step-metadata-conditionally-in-workflows/154055


### PR DESCRIPTION
Possible fixes for the [build error on Windows](https://github.com/trixi-framework/HOHQMesh/runs/6729482311?check_suite_focus=true) for `main`:
* ~~User previous GH environment Windows 2019~~ Does not work at all (msys2 not working, see 336df420df41070b756dbf0c70f349de76bf476a)
* ~~Downgrade to gfortran v11.3~~ Not possible using msys2, see, e.g., [here](https://stackoverflow.com/a/33986757/1329844) and 95b4cdcc2e3a4ffffd86f274d2cd2589178c56d7
* ~~Reproduce error with GCC 12.1 under Linux/macOS and fix it there~~ Error not reproducible on roci
* Compile with debug symbols for more useful error message **NOT TESTED**
* Run tests through gdb for more useful error message **NOT TESTED**
* Use `gcc-fortran` [package](https://packages.msys2.org/package/gcc-fortran?repo=msys&variant=x86_64) in msys2 ✅ 