### PR TITLE
Explicitly add gfortran to Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
         if: ${{ matrix.os == 'windows-latest' }}
         with:
           update: true
-          install: git base-devel mingw-w64-x86_64-toolchain
+          install: git base-devel mingw-w64-x86_64-toolchain mingw-w64-x86_64-gcc-fortran
       - uses: actions/cache@v4
         id: cache
         with:


### PR DESCRIPTION
This is the same fix for the Windows CI used in the [FTObjectLibrary](https://github.com/trixi-framework/FTObjectLibrary/pull/44).