### PR TITLE
Allow larger numbers in ABAQUS output

### DIFF
--- a/Source/IO/MeshOutputMethods.f90
+++ b/Source/IO/MeshOutputMethods.f90
@@ -367,7 +367,7 @@
          DO WHILE(.NOT.iterator % isAtEnd())
             obj => iterator % object()
             CALL castToSMNode(obj,node)
-            WRITE(iUnit, '(I0,3(", ", F18.13))') j, node % x
+            WRITE(iUnit, '(I0,3(", ", F20.12))') j, node % x
             CALL iterator % moveToNext()
             j = j + 1
          END DO
@@ -410,7 +410,7 @@
             DO k = 1, 4
                IF( e % boundaryInfo % bCurveFlag(k) == ON )     THEN
                   DO j = 0, N
-                     WRITE(iUnit, '(A3,3(F18.13))') "** ", e % boundaryInfo % x(:,j,k)
+                     WRITE(iUnit, '(A3,3(F20.12))') "** ", e % boundaryInfo % x(:,j,k)
                   END DO
                END IF
             END DO

--- a/Source/Mesh/MeshQualityAnalysis.f90
+++ b/Source/Mesh/MeshQualityAnalysis.f90
@@ -79,7 +79,7 @@
                             JACOBIAN_INDEX    = 5, MIN_ANGLE_INDEX    = 6, &
                             MAX_ANGLE_INDEX   = 7, AREA_SIGN          = 8
 
-      REAL(KIND=RP), PARAMETER, PRIVATE :: FUDGE_FACTOR_HIGH = 1.1_RP, FUDGE_FACTOR_LOW = 0.9
+      REAL(KIND=RP), PARAMETER, PRIVATE :: FUDGE_FACTOR_HIGH = 1.1_RP, FUDGE_FACTOR_LOW = 0.9_RP
 !
 !     ----------------------
 !     Quality measure arrays


### PR DESCRIPTION
Adds to the width of real numbers in the formatted output necessary in the ABAQUS format.