### PR TITLE
Add JOSS paper to README and add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,57 @@
+cff-version: "1.2.0"
+authors:
+- family-names: Kopriva
+  given-names: David A.
+  orcid: "https://orcid.org/0000-0002-8076-0856"
+- family-names: Winters
+  given-names: Andrew R.
+  orcid: "https://orcid.org/0000-0002-5902-1522"
+- family-names: Schlottke-Lakemper
+  given-names: Michael
+  orcid: "https://orcid.org/0000-0002-3195-2536"
+- family-names: Schoonover
+  given-names: Joseph A.
+  orcid: "https://orcid.org/0000-0001-5650-7095"
+- family-names: Ranocha
+  given-names: Hendrik
+  orcid: "https://orcid.org/0000-0002-3456-2277"
+contact:
+- family-names: Winters
+  given-names: Andrew R.
+  orcid: "https://orcid.org/0000-0002-5902-1522"
+doi: 10.5281/zenodo.14342391
+message: If you use this software, please cite our article in the
+  Journal of Open Source Software.
+preferred-citation:
+  authors:
+  - family-names: Kopriva
+    given-names: David A.
+    orcid: "https://orcid.org/0000-0002-8076-0856"
+  - family-names: Winters
+    given-names: Andrew R.
+    orcid: "https://orcid.org/0000-0002-5902-1522"
+  - family-names: Schlottke-Lakemper
+    given-names: Michael
+    orcid: "https://orcid.org/0000-0002-3195-2536"
+  - family-names: Schoonover
+    given-names: Joseph A.
+    orcid: "https://orcid.org/0000-0001-5650-7095"
+  - family-names: Ranocha
+    given-names: Hendrik
+    orcid: "https://orcid.org/0000-0002-3456-2277"
+  date-published: 2024-12-11
+  doi: 10.21105/joss.07476
+  issn: 2475-9066
+  issue: 104
+  journal: Journal of Open Source Software
+  publisher:
+    name: Open Journals
+  start: 7476
+  title: "HOHQMesh: An All Quadrilateral/Hexahedral Unstructured Mesh
+    Generator for High Order Elements"
+  type: article
+  url: "https://joss.theoj.org/papers/10.21105/joss.07476"
+  volume: 9
+title: "HOHQMesh: An All Quadrilateral/Hexahedral Unstructured Mesh
+  Generator for High Order Elements"
+

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Coveralls](https://coveralls.io/repos/github/trixi-framework/HOHQMesh/badge.svg?branch=main)](https://coveralls.io/github/trixi-framework/HOHQMesh?branch=main)
 [![Codecov](https://codecov.io/gh/trixi-framework/HOHQMesh/branch/main/graph/badge.svg)](https://codecov.io/gh/trixi-framework/HOHQMesh)
 [![License: MIT](https://img.shields.io/badge/License-MIT-success.svg)](https://opensource.org/licenses/MIT)
+[![JOSS](https://joss.theoj.org/papers/10.21105/joss.07476/status.svg)](https://doi.org/10.21105/joss.07476)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.13959058.svg)](https://doi.org/10.5281/zenodo.13959058)
 
 <p align="center">
@@ -180,9 +181,24 @@ the different formats of the resulting mesh files, and visualization instruction
 
 
 ## Referencing
-If you use HOHQMesh in your own research, please cite this repository as follows:
+If you use HOHQMesh in your own research, please cite the following article:
 ```bibtex
-@misc{kopriva2024hohqmesh,
+@article{kopriva2024hohqmesh:joss,
+  title={{HOHQM}esh: An All Quadrilateral/Hexahedral Unstructured Mesh Generator for High Order Elements},
+  author={David A. Kopriva and Andrew R. Winters and Michael Schlottke-Lakemper
+          and Joseph A. Schoonover and Hendrik Ranocha},
+  year={2024},
+  journal={Journal of Open Source Software},
+  doi={10.21105/joss.07476},
+  volume = {9},
+  number = {104},
+  pages = {7476},
+  publisher = {The Open Journal}
+}
+```
+In addition, you can also directly refer to this repository as
+```bibtex
+@misc{kopriva2024hohqmesh:repo,
   title={{HOHQM}esh: An All Quadrilateral/Hexahedral Unstructured Mesh Generator for High Order Elements},
   author={Kopriva, David A and Winters, Andrew R and Schlottke-Lakemper, Michael
           and Schoonover, Joseph A and Ranocha, Hendrik},


### PR DESCRIPTION
In the README, I kept both the bibtex for the JOSS paper and the actual repo. However, this might be overkill, thus I'm happy to remove it if you think it is too much.

The citation file is copied from the JOSS review issue [here](https://github.com/openjournals/joss-reviews/issues/7476#issuecomment-2535682678).