### PR TITLE
Adjust CI so gfortran 10 tests run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,13 +47,13 @@ jobs:
             shell: bash
             test_type: valgrind
             coverage: false
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             os_name: linux
             compiler: gfortran-10
             shell: bash
             test_type: regular
             coverage: true
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             os_name: linux
             compiler: gfortran-10
             shell: bash


### PR DESCRIPTION
The `gfortran-10` compiler is available in `ubuntu-22.04` and no longer in `ubuntu-latest`. See (https://github.com/actions/runner-images/issues/10636).