### PR TITLE
Fix docs build

### DIFF
--- a/Documentation/docs/introduction.md
+++ b/Documentation/docs/introduction.md
@@ -1,7 +1,7 @@
 
 # TL;DR. What you can do with HOHQMesh<a name="WhatToDo"></a>
 
-To use HOHQMesh to generate all-quadrilateral meshes with arbitrary order boundary elements you use a [control file](the-controlfile.md) to
+To use HOHQMesh to generate all-quadrilateral meshes with arbitrary order boundary elements you use a [control file](the-control-file.md) to
 
 - Define a [`MODEL`](the-model.md#TheModel) consisting of
 	- An optional closed outer [boundary curve](the-model.md#Boundaries) made up of one or a chain of curved segments defined by primitives like straight [line segments](the-model.md#EndPointsLine), [circular arcs](the-model.md#CircularArc), [elliptic arcs](the-model.md#ParametricEqn), [splines](the-model.md#Spline), or [equations](the-model.md#ParametricEqn)

--- a/Documentation/mkdocs.yml
+++ b/Documentation/mkdocs.yml
@@ -49,9 +49,9 @@ markdown_extensions:
       generic: true
   - toc:
       permalink: true
-  - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  # - pymdownx.emoji:
+  #     emoji_index: !!python/name:materialx.emoji.twemoji
+  #     emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.superfences
 
 extra_javascript:

--- a/Documentation/preparedocs
+++ b/Documentation/preparedocs
@@ -9,6 +9,7 @@ cp README.md docs/building-the-documentation.md
 
 sed -i.bak "s/\[AUTHORS.md\](AUTHORS.md)/the [Authors](authors.md) section/" docs/index.md
 sed -i.bak "s/\[LICENSE.md\](LICENSE.md)/the [License](license.md) section/" docs/index.md
+sed -i.bak 's|](Documentation/docs/\([^)]*\))|]\(\1)|g' docs/index.md
 sed -i.bak "s/\[gallery\](Documentation\/docs\/Gallery.md)/\[gallery\](Gallery.md)/" docs/index.md
 sed -i.bak "s/\[LICENSE.md\](LICENSE.md)/the [License](license.md) section/" docs/authors.md
 sed -i.bak "s/\[AUTHORS.md\](AUTHORS.md)/[Authors](authors.md)/" docs/license.md

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ please see the [gallery](https://trixi-framework.github.io/HOHQMesh/Gallery/).
 
 # What you can do with HOHQMesh<a name="WhatToDo"></a>
 
-To use HOHQMesh to generate all-quadrilateral meshes with arbitrary order boundary elements you use a [control file](Documentation/docs/the-controlfile.md) to
+To use HOHQMesh to generate all-quadrilateral meshes with arbitrary order boundary elements you use a [control file](Documentation/docs/the-control-file.md) to
 
 - Define a [`MODEL`](Documentation/docs/the-model.md#TheModel) consisting of
 	- An optional closed outer [boundary curve](Documentation/docs/the-model.md#Boundaries) made up of one or more connected curved segments defined by primitives like straight [line segments](Documentation/docs/the-model.md#EndPointsLine), [circular arcs](Documentation/docs/the-model.md#CircularArc), [elliptic arcs](Documentation/docs/the-model.md#ParametricEqn), [splines](Documentation/docs/the-model.md#Spline), or [equations](Documentation/docs/the-model.md#ParametricEqn)
 	- Zero or more closed inner boundary curves defined in the same way
 	- Zero or more internal boundary curves that define boundaries for multiple material applications
-	- An optional bottom [topography](Documentation/docs/three-dimensional-hexahedral-meshes.md#Topography) defined either in functional form or from a file to use to [refine](Documentation/docs/the-model.md.md#SizingTopography) a 2D mesh around bottom features. (For example for shallow water equation computations.)
+	- An optional bottom [topography](Documentation/docs/three-dimensional-hexahedral-meshes.md#Topography) defined either in functional form or from a file to use to [refine](Documentation/docs/the-model.md#SizingTopography) a 2D mesh around bottom features. (For example for shallow water equation computations.)
 
 - Tell it how to mesh the model with a [`CONTROL_INPUT`](Documentation/docs/the-control-input.md) section by
   - Setting [run parameters](Documentation/docs/the-control-input.md#RunParameters) that specify where to write the results, specify the mesh and plot file formats and set the polynomial order of the boundary curves
@@ -124,7 +124,7 @@ make -j 4 FC=gfortran-10
 ```
 
 #### Using CMake
-For a CMake-based build, you first need to build the 
+For a CMake-based build, you first need to build the
 [FTObjectLibrary](https://github.com/trixi-framework/FTObjectLibrary), install it, and then
 build HOHQMesh itself. If you followed the steps for obtaining the sources
 [above](#obtaining-the-sources), all required files are already present.


### PR DESCRIPTION
With new introduction section an extra `sed` command was needed in the `preparedocs` script when copying over the information from the README.md to become `Documentation/docs/index.md`.