### PR TITLE
EnableNoOutboundaryDef

### DIFF
--- a/Source/3DSource/Mesh3DOutputMethods.f90
+++ b/Source/3DSource/Mesh3DOutputMethods.f90
@@ -159,7 +159,7 @@
          CHARACTER(LEN=*)          :: fName
          INTEGER                   :: N ! The polynomial order of the boundaries.
          INTEGER                   :: version !version number of the ISM format.
-         CHARACTER(LEN=*)          :: materialNameForID(:)
+         CHARACTER(LEN=*)          :: materialNameForID(0:)
 !
 !        ---------------
 !        Local Variables

--- a/Source/Foundation/ProgramGlobals.f90
+++ b/Source/Foundation/ProgramGlobals.f90
@@ -90,7 +90,7 @@
 !        Misc
 !        ----
 !
-         INTEGER :: BACKGROUND_MATERIAL_ID = 1
+         INTEGER :: BACKGROUND_MATERIAL_ID = 0
 !
 !        -----------
 !        Preferences

--- a/Source/Mesh/MeshGeneratorMethods.f90
+++ b/Source/Mesh/MeshGeneratorMethods.f90
@@ -263,7 +263,7 @@
 
       IF ( model % numberOfInterfaceCurves > 0 )     THEN
 
-            ALLOCATE(CHARACTER(SM_CURVE_NAME_LENGTH) :: mesh % materialNameForID(numberOfBoundaries))
+            ALLOCATE(CHARACTER(SM_CURVE_NAME_LENGTH) :: mesh % materialNameForID(0:numberOfBoundaries))
             mesh % materialNameForID = project % backgroundMaterialName
 
             iterator => model % interfaceBoundariesIterator


### PR DESCRIPTION
Make the default material id 0 instead of 1 so that if there is no outer boundary the background material will always be given by the background material name. This is in reference to issue #137 .