### PR TITLE
Remove polyfill-io extension from mkdocs documentation

### DIFF
--- a/Documentation/mkdocs.yml
+++ b/Documentation/mkdocs.yml
@@ -57,7 +57,6 @@ markdown_extensions:
 
 extra_javascript:
   - javascripts/config.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
 extra_css:


### PR DESCRIPTION
HOHQMesh docs site was loading a script from https://polyfill.io/v3/polyfill.min.js. The polyfill.io domain was sold to a new owner in mid-2024, who began injecting malware into the served scripts. On the docs, the main symptom is a fake "Sign in" popup that tries to phish credentials from anyone visiting the documentation.


<img width="2258" height="652" alt="Screenshot from 2026-07-14 10-32-55" src="https://github.com/user-attachments/assets/8f78c744-07c0-48a6-a0c7-569195ab6f85" />

I removed the single offending line from Documentation/mkdocs.yml:60. I've confirmed that math rendering is completely unaffected and no other functionality in the documentation relies on polyfill.

Once this PR is merged, that pop-up will go away