### PR TITLE
Change CI from `ifort` to `ifx` and add `gfortran15` on linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,9 @@ on:
         default: false
 
 env:
-  # Modify this variable to change the ifort compiler version - do NOT hardcode the version
+  # Modify this variable to change the ifx compiler version - do NOT hardcode the version
   # anywhere else!
-  INTEL_ONEAPI_VERSION: 2023.2.1
+  INTEL_ONEAPI_VERSION: 2025.2
 
 jobs:
   test:
@@ -107,9 +107,21 @@ jobs:
             shell: bash
             test_type: valgrind
             coverage: false
+          - os: ubuntu-26.04
+            os_name: linux
+            compiler: gfortran-15
+            shell: bash
+            test_type: regular
+            coverage: false
+          - os: ubuntu-26.04
+            os_name: linux
+            compiler: gfortran-15
+            shell: bash
+            test_type: valgrind
+            coverage: false
           - os: ubuntu-latest
             os_name: linux
-            compiler: ifort
+            compiler: ifx
             shell: bash
             test_type: regular
             coverage: false
@@ -160,7 +172,7 @@ jobs:
           path: /opt/intel/oneapi
           key: ${{ matrix.os }}-${{ matrix.compiler }}-${{ env.INTEL_ONEAPI_VERSION }}
       - name: Install Intel oneAPI Fortran compiler
-        if: matrix.compiler == 'ifort' && steps.cache.outputs.cache-hit != 'true'
+        if: matrix.compiler == 'ifx' && steps.cache.outputs.cache-hit != 'true'
         run: |
           # download the key to system keyring
           wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB \
@@ -177,7 +189,7 @@ jobs:
           . /opt/intel/oneapi/setvars.sh
           env | grep oneapi >> $GITHUB_ENV
       - name: Use existing Intel oneAPI Fortran compiler
-        if: matrix.compiler == 'ifort' && steps.cache.outputs.cache-hit == 'true'
+        if: matrix.compiler == 'ifx' && steps.cache.outputs.cache-hit == 'true'
         run: |
           # set environment variables and make them persistent across steps
           . /opt/intel/oneapi/setvars.sh

--- a/Documentation/docs/compiling-and-running-hohqmesh.md
+++ b/Documentation/docs/compiling-and-running-hohqmesh.md
@@ -2,7 +2,7 @@
 ## Quick Introduction <a name="Compiling"></a>
 HOHQMesh is currently being distributed on gitHub. In that repository is a makefile, plus source, documentation (which contains this document) and a directory of examples.
 
-HOHQMesh is written in fortran 2018. It is known to compile and run with `gfortran` on Mac/Linux/Windows and with `ifort` on Mac and Linux. At the time of this writing, HOHQMesh compiles, but does not run correctly, with the nFortran compiler from nvidia. Let us know if there are issues with other compilers, or more recent versions of those.
+HOHQMesh is written in fortran 2018. It is known to compile and run with `gfortran` on Mac/Linux/Windows and with `ifx` on Mac and Linux. At the time of this writing, HOHQMesh compiles, but does not run correctly, with the nFortran compiler from nvidia. Let us know if there are issues with other compilers, or more recent versions of those.
 
 The mesher has one dependency, FTObjectLibrary, which supplies the container classes and exception classes. It is also available on gitHub under a project of that name.
 
@@ -73,7 +73,7 @@ For example, to build HOHQMesh specifically with the Fortran compiler
 make -j 4 FC=gfortran-10
 ```
 
-HOHQMesh is tested to run with the `gfortran` and `ifort` compilers. We recommend the `gfortran` compiler. Our experience on the test suite is that it runs about 50% slower with the `ifort` compiler.
+HOHQMesh is tested to run with the `gfortran` and `ifx` compilers. We recommend the `gfortran` compiler.
 
 ### Testing
 After building HOHQMesh, you can verify that everything works as expected by


### PR DESCRIPTION
Intel has officially deprecated the compiler `ifort` in favor of their new standard fortran compiler `ifx`. This changes CI to use `ifx` and adds additional CI testing for `gfortran15` on Linux (with and without valgrind).