### PR TITLE
Fix tolerance read-in for optimzation parameters

### DIFF
--- a/Source/Project/Model/SMModel.f90
+++ b/Source/Project/Model/SMModel.f90
@@ -604,7 +604,7 @@
             END IF
 
             IF ( curveDict % containsKey(CHAIN_TOLERANCE_KEY) )     THEN
-               curveChain % tolerance = curveDict % realValueForKey(CHAIN_TOLERANCE_KEY)
+               curveChain % tolerance = curveDict % doublePrecisionValueForKey(CHAIN_TOLERANCE_KEY)
             ELSE
                curveChain % tolerance = 1.0d-3
                str = "Optimization tolerance key not found in " // &


### PR DESCRIPTION
Use `doublePrecisionValueForKey` instead of `realValueForKey` to read-in the tolerance value.